### PR TITLE
Fix disabled prompt optimizer validation

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -2360,6 +2360,21 @@ class FeiHouEasyH3:
         }
 
     @classmethod
+    def VALIDATE_INPUTS(cls, advanced, prompt_optimizer_enabled, prompt_optimizer_provider, prompt_optimizer_scene_guide):
+        if not (_as_bool(advanced) and _as_bool(prompt_optimizer_enabled)):
+            return True
+
+        provider = str(prompt_optimizer_provider or "")
+        if not provider or provider not in _prompt_optimizer_provider_choices():
+            return f"提示词优化服务不可用：{provider or '未选择'}。请在 Easy H3 设置中配置并重新选择服务与模型。"
+
+        scene_guide = str(prompt_optimizer_scene_guide or "none")
+        scene_guides, _default_scene_guide = _prompt_optimizer_scheme_choices()
+        if scene_guide not in scene_guides:
+            return f"提示词优化场景方案不可用：{scene_guide}。请重新选择场景方案。"
+        return True
+
+    @classmethod
     def IS_CHANGED(cls, **kwargs):
         return float("nan")
 

--- a/web/feihou_easy_h3_ui.js
+++ b/web/feihou_easy_h3_ui.js
@@ -1627,11 +1627,12 @@ function patchGraphToPrompt() {
             promptNode.inputs.seconds = Math.min(MAX_SECONDS, Math.max(MIN_SECONDS, Number(getWidgetValue(node, "seconds", 10)) || 10));
             const advanced = asBoolean(getWidgetValue(node, "advanced", false));
             const optimizerEnabled = advanced && asBoolean(getWidgetValue(node, "prompt_optimizer_enabled", false));
-            // Keep a valid service-model value in the serialized prompt even
-            // when optimization is off.  ComfyUI validates combo values before
-            // execution; the enable switch below remains the sole execution
-            // gate, so this never calls an API while disabled.
-            const providerId = canonicalPromptProvider(getWidgetValue(node, "prompt_optimizer_provider", ""));
+            // Preserve the widget selection for later use, but do not submit a
+            // stale provider while optimization is disabled. ComfyUI validates
+            // combo values before node execution.
+            const providerId = optimizerEnabled
+                ? canonicalPromptProvider(getWidgetValue(node, "prompt_optimizer_provider", ""))
+                : "";
             promptNode.inputs.advanced = advanced;
             delete promptNode.inputs.prompt_optimizer_settings;
             promptNode.inputs.prompt_optimizer_enabled = optimizerEnabled;


### PR DESCRIPTION
## Summary

- Submit an empty prompt optimizer provider when optimization is disabled while preserving the saved widget selection.
- Validate provider/model and scene guide values only when prompt optimization is active.
- Keep enabled optimization strict so removed or invalid configurations still fail with an actionable message.

## Root cause

ComfyUI validates combo inputs before node execution. A workflow could therefore fail on a saved localized or removed provider/model value even though prompt optimization was disabled and the backend would never call it.

## User impact

Existing workflows with prompt optimization disabled can be queued without editing stale provider values. API and older frontend callers receive the same conditional backend validation.

## Checks

- Python syntax compilation
- JavaScript syntax validation
- ComfyUI validation matrix for disabled, advanced-off, valid enabled, invalid provider, and invalid scene guide cases
- Frontend serialization check for disabled and enabled optimizer states
